### PR TITLE
Add question mark to advanced example query

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -69,7 +69,7 @@ function Examples(props) {
   ]
   const advanced_example_queries = [
     "3 neighborhoods in San Francisco that have the highest female to male ratio",
-    "Which area in San Francisco has the highest racial diversity and what is the percentage population of each race in that area",
+    "Which area in San Francisco has the highest racial diversity and what is the percentage population of each race in that area?",
     // "Which 5 areas have the median income closest to the national median income?"
   ]
   return (


### PR DESCRIPTION
Added a question mark to the question "Which area in San Francisco has the highest racial diversity and what is the percentage population of each race in that area?" that appears as an "Advanced" example query on the website.