### PR TITLE
change to postpresql:// in config.py

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine
 
-DB_URL = "postgres://census_data_user:BvgUaxoocxdDrJ9Mam4HHkacPBWLYYt9@dpg-cg59te3hp8u9l20dqd40-b.replica-cyan.oregon-postgres.render.com/census_data"
+DB_URL = "postgresql://census_data_user:BvgUaxoocxdDrJ9Mam4HHkacPBWLYYt9@dpg-cg59te3hp8u9l20dqd40-b.replica-cyan.oregon-postgres.render.com/census_data"
 OPENAI_KEY = "OPENAI_KEY"
 
 class FlaskAppConfig:


### PR DESCRIPTION
The URI should start with postgresql:// instead of postgres://. SQLAlchemy used to accept both, but has removed support for the postgres name.

https://stackoverflow.com/questions/62688256/sqlalchemy-exc-nosuchmoduleerror-cant-load-plugin-sqlalchemy-dialectspostgre