### PR TITLE
hide disclaimer on mobile

### DIFF
--- a/client/src/components/disclaimer.js
+++ b/client/src/components/disclaimer.js
@@ -1,6 +1,6 @@
 const Disclaimer = () => {
     return (
-        <div className="flex items-center mt-2 justify-center">
+        <div className="hidden flex items-center mt-2 justify-center md:block">
             <p className="text-xs tracking-tight text-gray-600 dark:text-white">
                 Disclaimer: CensusGPT currently only supports data about crime,
                 age, race, gender, income, and population in the USA. But we are


### PR DESCRIPTION
- overlay the toggles over the map (#86)
- plotly dark mode and viz selector styles
- tables json
- hide disclaimer on mobile
