### PR TITLE
Update API dev instructions

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -5,9 +5,9 @@
 
 ## Required configuration for development:
 - OpenAI Key
-- URL to the postgres DB (Read-only URL provided in `config.py`)
+- URL to the postgres DB (Read-only URL provided in `.env.example`)
 
-Configure the above in `app/config.py`
+Make a copy of `.env.example`, rename it to `.env`, and configure the above variables.
 
 ## Local development
 


### PR DESCRIPTION
I think OpenAI key and Postgres configuration was in `/api/app/config.py` at some point, but later it was moved to `.env`. This PR intends to get README up-to-date with the code.